### PR TITLE
Fix unit type recognition when file edited using `systemctl edit` cmd

### DIFF
--- a/systemd_language_server/unit.py
+++ b/systemd_language_server/unit.py
@@ -192,7 +192,11 @@ def get_directives(unit_type: UnitType, section: UnitFileSection | None) -> list
 
 
 def get_unit_type(document):
-    return UnitType(Path(document.uri).suffix.strip("."))
+    unit_types_pattern = "|".join([i.value for i in UnitType])
+    file_extension = Path(document.uri).suffix.removeprefix(".")
+    unit_type_match = re.match(unit_types_pattern, file_extension)
+    unit_type = unit_type_match[0] if unit_type_match else None
+    return UnitType(unit_type)
 
 
 def get_current_section(


### PR DESCRIPTION
Hello! I like your language server, it's very helpful for a newbie in systemd unit files.
This PR fixes problem when you edit/create unit file using `systemctl edit  --full` command

I want to point out that there is another bug, if you overriding service using `systemctl edit` command without `--full` argument, it's opens something like `~/.config/systemd/user/syncthing.service.d/.#override.confafc30fc0826930be`. So figuring out unit type requires another approach.
It requires more changes to fix this bug than this PR and I'm not sure if you would accept them